### PR TITLE
Implement friend discovery page

### DIFF
--- a/SchoolAssisstant.xcodeproj/project.pbxproj
+++ b/SchoolAssisstant.xcodeproj/project.pbxproj
@@ -70,7 +70,8 @@
 		E39C60B02E0DBAB2006B4C39 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E39C604A2E0DBAB2006B4C39 /* GoogleService-Info.plist */; };
 		E3C94B822E34E157004D8262 /* StudySessionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C94B812E34E157004D8262 /* StudySessionModel.swift */; };
 		E3C94B842E34E22A004D8262 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E3C94B832E34E22A004D8262 /* Media.xcassets */; };
-		E3C94B862E351657004D8262 /* FriendDiscoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C94B852E351657004D8262 /* FriendDiscoveryView.swift */; };
+                E3C94B862E351657004D8262 /* FriendDiscoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C94B852E351657004D8262 /* FriendDiscoveryView.swift */; };
+                6B5BB6B07029239DCEFEF2DF /* FriendDiscoveryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D7D21246204CB638B09098 /* FriendDiscoveryViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -128,7 +129,8 @@
 		E3C94B802E34E0A7004D8262 /* SchoolAssisstant.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SchoolAssisstant.entitlements; sourceTree = "<group>"; };
 		E3C94B812E34E157004D8262 /* StudySessionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudySessionModel.swift; sourceTree = "<group>"; };
 		E3C94B832E34E22A004D8262 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
-		E3C94B852E351657004D8262 /* FriendDiscoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendDiscoveryView.swift; sourceTree = "<group>"; };
+                E3C94B852E351657004D8262 /* FriendDiscoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendDiscoveryView.swift; sourceTree = "<group>"; };
+                D1D7D21246204CB638B09098 /* FriendDiscoveryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendDiscoveryViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -215,9 +217,10 @@
 			children = (
 				E39C60522E0DBAB2006B4C39 /* NotesViewModel.swift */,
 				E39C60532E0DBAB2006B4C39 /* SignUpEmailViewModel.swift */,
-				E39C60542E0DBAB2006B4C39 /* SocialViewModel.swift */,
-				E39C60552E0DBAB2006B4C39 /* TasksViewModel.swift */,
-			);
+                               E39C60542E0DBAB2006B4C39 /* SocialViewModel.swift */, 
+                               E39C60552E0DBAB2006B4C39 /* TasksViewModel.swift */,
+                                D1D7D21246204CB638B09098 /* FriendDiscoveryViewModel.swift */,
+                        );
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
@@ -474,8 +477,9 @@
 				E39C609B2E0DBAB2006B4C39 /* TaskItem.swift in Sources */,
 				E39C609C2E0DBAB2006B4C39 /* IntroPagesView.swift in Sources */,
 				E39C609D2E0DBAB2006B4C39 /* TextManager.swift in Sources */,
-				E3C94B862E351657004D8262 /* FriendDiscoveryView.swift in Sources */,
-				E39C609E2E0DBAB2006B4C39 /* NotesManager.swift in Sources */,
+                                E3C94B862E351657004D8262 /* FriendDiscoveryView.swift in Sources */,
+                                6B5BB6B07029239DCEFEF2DF /* FriendDiscoveryViewModel.swift in Sources */,
+                                E39C609E2E0DBAB2006B4C39 /* NotesManager.swift in Sources */,
 				E39C609F2E0DBAB2006B4C39 /* UserManager.swift in Sources */,
 				E39C60A02E0DBAB2006B4C39 /* Utilities.swift in Sources */,
 				E39C60A12E0DBAB2006B4C39 /* NotesViewModel.swift in Sources */,

--- a/SchoolAssisstant/ViewModels/FriendDiscoveryViewModel.swift
+++ b/SchoolAssisstant/ViewModels/FriendDiscoveryViewModel.swift
@@ -1,0 +1,36 @@
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+@MainActor
+final class FriendDiscoveryViewModel: ObservableObject {
+    @Published var users: [DBUser] = []
+    @Published var searchText: String = ""
+
+    var filteredUsers: [DBUser] {
+        guard !searchText.isEmpty else { return users }
+        return users.filter { ($0.username ?? "").localizedCaseInsensitiveContains(searchText) }
+    }
+
+    func loadUsers() async {
+        do {
+            let fetched = try await UserManager.shared.getAllUsers()
+            if let current = Auth.auth().currentUser?.uid {
+                users = fetched.filter { $0.userId != current }
+            } else {
+                users = fetched
+            }
+        } catch {
+            print("Failed to load users: \(error)")
+            users = []
+        }
+    }
+
+    func sendRequest(to user: DBUser) {
+        guard let currentUser = UserManager.shared.currentUser else { return }
+        let theirDoc = UserManager.shared.userDocument(userId: user.userId)
+        theirDoc.updateData([
+            "pendingFriends": FieldValue.arrayUnion([currentUser.userId])
+        ])
+    }
+}

--- a/SchoolAssisstant/Views/SocialPage/FriendDiscoveryView.swift
+++ b/SchoolAssisstant/Views/SocialPage/FriendDiscoveryView.swift
@@ -1,16 +1,26 @@
 import SwiftUI
 
 struct FriendDiscoveryView: View {
+    @StateObject private var viewModel = FriendDiscoveryViewModel()
+
     var body: some View {
-        VStack {
-            Text("Friend Discovery")
-                .font(.largeTitle)
-                .padding()
-            Text("This is a placeholder for finding and adding new friends.")
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding()
+        List {
+            ForEach(viewModel.filteredUsers, id: \.id) { user in
+                HStack {
+                    Text(user.username ?? "no username")
+                    Spacer()
+                    Button("Add") {
+                        viewModel.sendRequest(to: user)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding(.vertical, 4)
+            }
         }
+        .listStyle(.plain)
+        .navigationTitle("Friend Discovery")
+        .searchable(text: $viewModel.searchText)
+        .task { await viewModel.loadUsers() }
     }
 }
 

--- a/SchoolAssisstant/Views/SocialPage/SocialView.swift
+++ b/SchoolAssisstant/Views/SocialPage/SocialView.swift
@@ -3,7 +3,6 @@ import UserNotifications
 
 struct FriendsView: View {
     @StateObject private var viewModel = FriendsViewModel()
-    @State private var showFriendDiscovery = false
     @State private var lastNotifiedRequests: Set<String> = [] // userIds of last notified
 
     var body: some View {
@@ -37,12 +36,10 @@ struct FriendsView: View {
                 .cornerRadius(8)
             }
 
-            Button("Find Friends") {
-                showFriendDiscovery = true
-            }
-
-            if showFriendDiscovery {
-                FriendDiscoveryView()
+            if viewModel.friends.isEmpty {
+                NavigationLink("Find Friends") {
+                    FriendDiscoveryView()
+                }
             }
 
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))]) {


### PR DESCRIPTION
## Summary
- add `FriendDiscoveryViewModel` for loading and searching users
- implement `FriendDiscoveryView` with user list and friend request button
- link to discovery page from `FriendsView` when no friends exist
- register new view model in the project configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885fba8d8bc832aa85e3a55d6605fcb