### PR TITLE
feat(ios): enhance intro pages with vibrant gradients

### DIFF
--- a/IOS/Study Bro/Study Bro/Models/Utility/IntroPagesModel.swift
+++ b/IOS/Study Bro/Study Bro/Models/Utility/IntroPagesModel.swift
@@ -5,20 +5,36 @@
 //  Created by OpenAI on 2025.
 //
 
-import Foundation
+import SwiftUI
 
 struct IntroPage: Identifiable {
     let id = UUID()
     let title: String
     let description: String
     let systemImage: String
+    let gradient: [Color]
 }
 
 struct IntroPagesModel {
     static let pages: [IntroPage] = [
-        IntroPage(title: "Welcome", description: "Welcome to StuddyBuddy ! Here, you can learn more effectively and more easily. This app has been build with the lates psychlogy techniques and learniing methods to automate your learning.", systemImage: "star"),
-        IntroPage(title: "Use AI", description: "With the AI we created, you will be able to chat with it in order to understant some subject better. The provided context makes it more awares of your goals, what you want to learn or even how you do it.", systemImage: "list.bullet.rectangle"),
-        IntroPage(title: "Stay Focused", description: "With lots of features all aiming to help you stay focuses and remember thing in short ot long term, this app gives you all teh chances for success in your studies.", systemImage: "timer")
+        IntroPage(
+            title: "Welcome",
+            description: "Welcome to StuddyBuddy ! Here, you can learn more effectively and more easily. This app has been build with the lates psychlogy techniques and learniing methods to automate your learning.",
+            systemImage: "sparkles",
+            gradient: [Color.purple, Color.blue]
+        ),
+        IntroPage(
+            title: "Use AI",
+            description: "With the AI we created, you will be able to chat with it in order to understant some subject better. The provided context makes it more awares of your goals, what you want to learn or even how you do it.",
+            systemImage: "brain.head.profile",
+            gradient: [Color.indigo, Color.teal]
+        ),
+        IntroPage(
+            title: "Stay Focused",
+            description: "With lots of features all aiming to help you stay focuses and remember thing in short ot long term, this app gives you all teh chances for success in your studies.",
+            systemImage: "timer",
+            gradient: [Color.orange, Color.pink]
+        )
     ]
 }
 

--- a/IOS/Study Bro/Study Bro/Views/IntroPages/IntroPagesView.swift
+++ b/IOS/Study Bro/Study Bro/Views/IntroPages/IntroPagesView.swift
@@ -15,24 +15,30 @@ struct IntroPagesView: View {
     
     var body: some View {
         ZStack {
-            Rectangle()
-                .fill(.ultraThinMaterial)
+            LinearGradient(colors: pages[currentPage].gradient,
+                           startPoint: .topLeading,
+                           endPoint: .bottomTrailing)
                 .ignoresSafeArea()
+
             VStack {
                 TabView(selection: $currentPage) {
                     ForEach(Array(pages.enumerated()), id: \.element.id) { index, page in
                         ZStack {
-                            VStack(spacing: 16) {
-//                                Image(systemName: page.systemImage)
-//                                    .resizable()
-//                                    .scaledToFit()
-//                                    .frame(width: 120, height: 120)
-//                                    .padding()
+                            VStack(spacing: 24) {
+                                Image(systemName: page.systemImage)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 120, height: 120)
+                                    .padding()
+                                    .foregroundStyle(
+                                        LinearGradient(colors: page.gradient,
+                                                       startPoint: .topLeading,
+                                                       endPoint: .bottomTrailing)
+                                    )
 
                                 Text(page.title)
                                     .font(.title)
                                     .fontWeight(.bold)
-                                
 
                                 Text(page.description)
                                     .font(.body)
@@ -47,6 +53,7 @@ struct IntroPagesView: View {
                     }
                 }
                 .tabViewStyle(PageTabViewStyle())
+                .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
 
                 Button {
                     if currentPage < pages.count - 1 {
@@ -55,11 +62,19 @@ struct IntroPagesView: View {
                         hasShownWelcome = true
                     }
                 } label: {
-                    Text("Continue")
-                        .foregroundStyle(.primary)
+                    Text(currentPage < pages.count - 1 ? "Next" : "Get Started")
+                        .fontWeight(.semibold)
                         .padding()
+                        .frame(maxWidth: .infinity)
                 }
-                .glassEffect()
+                .background(
+                    LinearGradient(colors: pages[currentPage].gradient,
+                                   startPoint: .leading,
+                                   endPoint: .trailing)
+                        .cornerRadius(12)
+                )
+                .foregroundColor(.white)
+                .shadow(radius: 5)
                 .padding()
             }
         }


### PR DESCRIPTION
## Summary
- add per-page gradients and colorful system icons
- apply dynamic gradient backgrounds and buttons for intro walk-through

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689cc5907714832aa6dda567fa6ae9dd