### PR TITLE
feat(ios): refresh onboarding design

### DIFF
--- a/IOS/Study Bro/Study Bro/Models/Utility/IntroPagesModel.swift
+++ b/IOS/Study Bro/Study Bro/Models/Utility/IntroPagesModel.swift
@@ -5,20 +5,36 @@
 //  Created by OpenAI on 2025.
 //
 
-import Foundation
+import SwiftUI
 
 struct IntroPage: Identifiable {
     let id = UUID()
     let title: String
     let description: String
     let systemImage: String
+    let gradient: [Color]
 }
 
 struct IntroPagesModel {
     static let pages: [IntroPage] = [
-        IntroPage(title: "Welcome", description: "Welcome to StuddyBuddy ! Here, you can learn more effectively and more easily. This app has been build with the lates psychlogy techniques and learniing methods to automate your learning.", systemImage: "star"),
-        IntroPage(title: "Use AI", description: "With the AI we created, you will be able to chat with it in order to understant some subject better. The provided context makes it more awares of your goals, what you want to learn or even how you do it.", systemImage: "list.bullet.rectangle"),
-        IntroPage(title: "Stay Focused", description: "With lots of features all aiming to help you stay focuses and remember thing in short ot long term, this app gives you all teh chances for success in your studies.", systemImage: "timer")
+        IntroPage(
+            title: "Welcome",
+            description: "Welcome to StuddyBuddy! Learn more effectively with modern psychology techniques and automated study helpers.",
+            systemImage: "sparkles",
+            gradient: [Color(hex: "#FF5F6D"), Color(hex: "#FFC371")]
+        ),
+        IntroPage(
+            title: "Use AI",
+            description: "Chat with our AI to better understand subjects. Context-aware conversations adapt to your goals and study style.",
+            systemImage: "brain.head.profile",
+            gradient: [Color(hex: "#2193b0"), Color(hex: "#6dd5ed")]
+        ),
+        IntroPage(
+            title: "Stay Focused",
+            description: "Stay on track with features designed to boost short- and long-term memory so you can succeed in your studies.",
+            systemImage: "timer",
+            gradient: [Color(hex: "#cc2b5e"), Color(hex: "#753a88")]
+        )
     ]
 }
 

--- a/IOS/Study Bro/Study Bro/Views/IntroPages/IntroPagesView.swift
+++ b/IOS/Study Bro/Study Bro/Views/IntroPages/IntroPagesView.swift
@@ -15,25 +15,33 @@ struct IntroPagesView: View {
     
     var body: some View {
         ZStack {
-            Rectangle()
-                .fill(.ultraThinMaterial)
+            LinearGradient(colors: pages[currentPage].gradient,
+                           startPoint: .topLeading,
+                           endPoint: .bottomTrailing)
                 .ignoresSafeArea()
+                .animation(.easeInOut, value: currentPage)
+
             VStack {
                 TabView(selection: $currentPage) {
                     ForEach(Array(pages.enumerated()), id: \.element.id) { index, page in
                         ZStack {
-                            VStack(spacing: 16) {
-//                                Image(systemName: page.systemImage)
-//                                    .resizable()
-//                                    .scaledToFit()
-//                                    .frame(width: 120, height: 120)
-//                                    .padding()
-
+                            VStack(spacing: 24) {
+                                Image(systemName: page.systemImage)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 120, height: 120)
+                                    .padding()
+                                    .symbolRenderingMode(.palette)
+                                    .foregroundStyle(
+                                        LinearGradient(colors: page.gradient,
+                                                       startPoint: .topLeading,
+                                                       endPoint: .bottomTrailing)
+                                    )
+                                
                                 Text(page.title)
                                     .font(.title)
                                     .fontWeight(.bold)
                                 
-
                                 Text(page.description)
                                     .font(.body)
                                     .multilineTextAlignment(.center)
@@ -48,18 +56,39 @@ struct IntroPagesView: View {
                 }
                 .tabViewStyle(PageTabViewStyle())
 
+                HStack(spacing: 8) {
+                    ForEach(pages.indices, id: \.self) { index in
+                        Circle()
+                            .fill(index == currentPage ? AnyShapeStyle(LinearGradient(colors: pages[index].gradient,
+                                                                                    startPoint: .top,
+                                                                                    endPoint: .bottom)) : AnyShapeStyle(Color.white.opacity(0.3)))
+                            .frame(width: 8, height: 8)
+                    }
+                }
+                .padding(.top, 8)
+
                 Button {
-                    if currentPage < pages.count - 1 {
-                        currentPage += 1
-                    } else {
-                        hasShownWelcome = true
+                    withAnimation {
+                        if currentPage < pages.count - 1 {
+                            currentPage += 1
+                        } else {
+                            hasShownWelcome = true
+                        }
                     }
                 } label: {
-                    Text("Continue")
-                        .foregroundStyle(.primary)
+                    Text(currentPage < pages.count - 1 ? "Next" : "Get Started")
+                        .fontWeight(.semibold)
                         .padding()
+                        .frame(maxWidth: .infinity)
                 }
-                .glassEffect()
+                .background(
+                    LinearGradient(colors: pages[currentPage].gradient,
+                                   startPoint: .leading,
+                                   endPoint: .trailing)
+                        .cornerRadius(AppTheme.cornerRadius)
+                )
+                .foregroundColor(.white)
+                .shadow(radius: 5)
                 .padding()
             }
         }


### PR DESCRIPTION
## Summary
- refine intro pages data with polished copy and vibrant hex gradients
- animate onboarding screens with custom gradient page dots and brand-styled CTA

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689cc5907714832aa6dda567fa6ae9dd